### PR TITLE
Only apply short URL to main page when it is set

### DIFF
--- a/includes/GloopTweaksHooks.php
+++ b/includes/GloopTweaksHooks.php
@@ -377,9 +377,9 @@ class GloopTweaksHooks {
 	 * because $wgMainPageIsDomainRoot doesn't apply to the internal URL, which is used for purging.
 	 */
 	public static function onGetLocalURLInternal( $title, &$url, $query ) {
-		global $wgArticlePath, $wgScript;
+		global $wgArticlePath, $wgScript, $wgMainPageIsDomainRoot;
 		$dbkey = wfUrlencode( $title->getPrefixedDBkey() );
-		if ( $title->isMainPage() ) {
+		if ( $title->isMainPage() && $wgMainPageIsDomainRoot ) {
 			$url = wfAppendQuery( '/', $query );
 		} elseif ( $url == "{$wgScript}?title={$dbkey}&{$query}" ) {
 			$url = wfAppendQuery(str_replace( '$1', $dbkey, $wgArticlePath ), $query );


### PR DESCRIPTION
When wgMainPageIsDomainRoot is not set, such overrides will cause redirect loop.