### PR TITLE
Fix site root URL in schema.org metadata with a new flag for Subnautica Wikis

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -166,6 +166,9 @@
 		"EnableStructuredData": {
 			"value": true
 		},
+		"DomainRootIsPrimarySite": {
+			"value": true
+		},
 		"NoRobots": {
 			"value": false
 		},

--- a/includes/GloopTweaksHooks.php
+++ b/includes/GloopTweaksHooks.php
@@ -500,7 +500,10 @@ EOD
 					'@context'        => 'http://schema.org',
 					'@type'           => 'WebSite',
 					'name'            => $siteName,
-					'url'             => $this->config->get( MainConfigNames::CanonicalServer ),
+					// If this flag is false, we're probably hosting multiple same-domain same-language wikis and need
+					// them to be treated as separate entities (WG-417).
+					'url'             => $this->config->get( 'GloopTweaksDomainRootIsPrimarySite' ) ?
+						$this->config->get( MainConfigNames::CanonicalServer ) : $title->getFullURL(),
 				];
 				$out->addHeadItem( 'StructuredData',
 					'<script type="application/ld+json">' . json_encode( $structuredData ) . '</script>' );


### PR DESCRIPTION
The flag lets us isolate this behaviour change to the Subnautica wikis, without affecting LoL where it's harder to predict what exact outcome we might get.

Fixes WG-417