### PR TITLE
Partially restore getContentFromWiki for FixedWidthStyleModule

### DIFF
--- a/includes/GloopTweaksUtils.php
+++ b/includes/GloopTweaksUtils.php
@@ -17,6 +17,7 @@ class GloopTweaksUtils {
 
 		return $wgGloopTweaksNetworkCentralDB && $wgDBname === $wgGloopTweaksNetworkCentralDB;
 	}
+
 	/**
 	 * @return BagOStuff
 	 */
@@ -29,6 +30,27 @@ class GloopTweaksUtils {
 		} else {
 			return $objectCacheFactory->getLocalClusterInstance();
 		}
+	}
+
+	/**
+	 * Fetches a page's content from current family's central wiki.
+	 * @param MediaWikiServices $services
+	 * @param string $pageName
+	 * @return Content|null
+	 */
+	public static function getContentFromFamilyCentralWiki( MediaWikiServices $services, string $pageName ) {
+		$config = $services->getMainConfig();
+		$wiki = $config->get( 'GloopTweaksFamilyCentralDB' );
+		$targetWikiIsCurrentWiki = $wiki === $config->get( MainConfigNames::DBname );
+		$page = $services->getPageStoreFactory()
+			->getPageStore( $targetWikiIsCurrentWiki ? WikiAwareEntity::LOCAL : $wiki )
+			->getPageByText( $pageName );
+		$rev = $services->getRevisionStoreFactory()
+			->getRevisionStore( $targetWikiIsCurrentWiki ? WikiAwareEntity::LOCAL : $wiki )
+			->getRevisionByTitle( $page );
+		$content = $rev ? $rev->getContent( SlotRecord::MAIN ) : null;
+
+		return $content;
 	}
 
 	/**

--- a/includes/ResourceLoader/FixedWidthStyleModule.php
+++ b/includes/ResourceLoader/FixedWidthStyleModule.php
@@ -16,13 +16,7 @@ class FixedWidthStyleModule extends SiteStylesModule {
 	 * @since 1.32 added the $context parameter
 	 */
 	protected function getContent( $titleText, Context $context ) {
-		global $wgGloopTweaksFamilyCentralDB;
-
-		$content = GloopTweaksUtils::getContentFromWiki(
-			MediaWikiServices::getInstance(),
-			$titleText,
-			$wgGloopTweaksFamilyCentralDB
-		);
+		$content = GloopTweaksUtils::getContentFromFamilyCentralWiki( MediaWikiServices::getInstance(), $titleText );
 
 		if ( !$content ) {
 			// No content found


### PR DESCRIPTION
... as `GloopTweaksUtils::getContentFromFamilyCentralWiki` to avoid accidental use on domains with a different shared actor table.

Fixes WG-423