### PR TITLE
Upgrade mediawiki/mediawiki-codesniffer to 51 and suppress PKSA-rdkp-…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"audit": {
+			"ignore": {
+				"PKSA-rdkp-vv9z-mjkg": "Only fixed for mediawiki/mediawiki-codesniffer 52 right now, which requires PHP 8.3"
+			}
 		}
 	}
 }


### PR DESCRIPTION
…vv9z-mjkg

We can't upgrade to 52 (which fixes the advisory), as we still need to support PHP 8.2.