### PR TITLE
Replace use of hard-deprecated wfExpandUrl() function

### DIFF
--- a/includes/GloopTweaksLuaLibrary.php
+++ b/includes/GloopTweaksLuaLibrary.php
@@ -44,7 +44,8 @@ class GloopTweaksLuaLibrary extends LibraryBase {
 				// ... and we can
 				if ( $mto && !$mto->isError() ) {
 					// ... change the URL to point to a thumbnail.
-					$url = wfExpandUrl( $mto->getUrl(), PROTO_RELATIVE );
+					$url = MediaWikiServices::getInstance()->getUrlUtils()
+						->expand( (string)$mto->getUrl(), PROTO_RELATIVE );
 				}
 			}
 			return [ $url ];


### PR DESCRIPTION
Emits deprecation warnings since 1.45.