### PR TITLE
Initialize ProfilingContext in entry points

### DIFF
--- a/entrypoints/robots.php
+++ b/entrypoints/robots.php
@@ -3,11 +3,14 @@
 
 use MediaWiki\Extension\GloopTweaks\GloopTweaksUtils;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Profiler\ProfilingContext;
 
 define( 'MW_NO_SESSION', 1 );
 define( 'MW_ENTRY_POINT', 'robots' );
 
 require dirname( $_SERVER['SCRIPT_FILENAME'] ) . '/includes/WebStart.php';
+
+ProfilingContext::singleton()->init( 'wg', MW_ENTRY_POINT );
 
 wfRobotsMain();
 

--- a/entrypoints/run_jobs.php
+++ b/entrypoints/run_jobs.php
@@ -11,6 +11,8 @@
  */
 
 // Validate request method
+use MediaWiki\Profiler\ProfilingContext;
+
 if ( $_SERVER['REQUEST_METHOD'] !== 'POST' ) {
 	http_response_code( 405 );
 	header( 'Allow: POST' );
@@ -32,6 +34,8 @@ define( 'MW_DB', $_GET['db'] );
 define( 'MEDIAWIKI_JOB_RUNNER', 1 );
 define( 'MW_ENTRY_POINT', 'run_jobs' );
 require dirname( $_SERVER['SCRIPT_FILENAME'] ) . '/includes/WebStart.php';
+
+ProfilingContext::singleton()->init( 'wg', MW_ENTRY_POINT );
 
 // Verify request signature
 $signedNames = [ 'db', 'maxjobs', 'maxmem', 'maxtime', 'sigexpiry', 'type' ];

--- a/entrypoints/static.php
+++ b/entrypoints/static.php
@@ -3,10 +3,14 @@
 // Based on
 //	https://github.com/wikimedia/operations-mediawiki-config/blob/4cd21ef34b81dd10b04c230f7e9eedc66bce1a87/w/static.php
 
+use MediaWiki\Profiler\ProfilingContext;
+
 define( 'MW_NO_SESSION', 1 );
 define( 'MW_ENTRY_POINT', 'static' );
 
 require dirname( $_SERVER['SCRIPT_FILENAME'] ) . '/includes/WebStart.php';
+
+ProfilingContext::singleton()->init( 'wg', MW_ENTRY_POINT );
 
 /**
  * @param int $status

--- a/entrypoints/stream_file.php
+++ b/entrypoints/stream_file.php
@@ -2,11 +2,14 @@
 // This file is intended to be symlinked into $IP.
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Profiler\ProfilingContext;
 
 define( 'MW_NO_SESSION', 1 );
 define( 'MW_ENTRY_POINT', 'stream_file' );
 
 require dirname( $_SERVER['SCRIPT_FILENAME'] ) . '/includes/WebStart.php';
+
+ProfilingContext::singleton()->init( 'wg', MW_ENTRY_POINT );
 
 // phpcs:ignore MediaWiki.Usage.SuperGlobalsUsage.SuperGlobals
 wfStreamFileMain( $_GET );


### PR DESCRIPTION
This way, they will show up correctly in Grafana, e.g. as `wg_robots`, and not `unknown_unknown` like right now.

See https://gerrit.wikimedia.org/r/c/operations/mediawiki-config/+/1327652 for a similar patch in WMF's config repo